### PR TITLE
Hotfix Non-Suspensible Machine Generation

### DIFF
--- a/Sources/VHDLMachines/Machine.swift
+++ b/Sources/VHDLMachines/Machine.swift
@@ -65,9 +65,17 @@ public struct Machine: Codable, Equatable, Hashable {
     /// Whether the machine is parameterised.
     private var _isParameterised: Bool
 
-    /// Whether the machine is parameterised.
+    /// Whether the machine is parameterised. Setting this value to `true` will not necessarily make the
+    /// machine parameterised. The machine must also have a suspended state for this to be `true`.
     public var isParameterised: Bool {
-        _isParameterised && suspendedState != nil
+        get {
+            _isParameterised && suspendedState != nil
+        }
+        set {
+            if suspendedState != nil {
+                _isParameterised = newValue
+            }
+        }
     }
 
     /// Whether the machine can be suspended.

--- a/Sources/VHDLMachines/codeStructure/CaseStatement+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/CaseStatement+machineInit.swift
@@ -62,7 +62,7 @@ extension CaseStatement {
     /// Create the case statement for the actions in a machine.
     /// - Parameter machine: The machine to create the case statement from.
     init?(machine: Machine) {
-        let actions = (
+        var actions = (
             machine.actions + [
                 VariableName.noOnEntry,
                 VariableName.readSnapshot,
@@ -70,6 +70,9 @@ extension CaseStatement {
                 VariableName.checkTransition
             ]
         ).sorted()
+        if !machine.isSuspensible {
+            actions = actions.filter { $0 != VariableName.onResume && $0 != VariableName.onSuspend }
+        }
         let cases = actions.compactMap { WhenCase(machine: machine, action: $0) }
         guard cases.count == actions.count else {
             return nil

--- a/Sources/VHDLMachines/codeStructure/WhenCase+machineInit.swift
+++ b/Sources/VHDLMachines/codeStructure/WhenCase+machineInit.swift
@@ -209,7 +209,10 @@ extension WhenCase {
 
     /// Create the onResume action for a machine.
     /// - Parameter machine: The machine to create the onResume action for.
-    private init(onResumeMachine machine: Machine) {
+    private init?(onResumeMachine machine: Machine) {
+        guard machine.isSuspensible else {
+            return nil
+        }
         let stateCases = machine.states.compactMap { state -> WhenCase? in
             let condition = WhenCondition.expression(expression: .variable(name: .name(for: state)))
             var code: [SynchronousBlock] = []

--- a/Tests/VHDLMachinesTests/MachineTests.swift
+++ b/Tests/VHDLMachinesTests/MachineTests.swift
@@ -58,6 +58,8 @@
 import VHDLParsing
 import XCTest
 
+// swiftlint:disable type_body_length
+
 /// Tests the ``Machine`` type.
 final class MachineTests: XCTestCase {
 
@@ -415,7 +417,30 @@ final class MachineTests: XCTestCase {
         XCTAssertEqual(machine, expected)
     }
 
+    /// Test `isParameterised` setter.
+    func testIsParameterisedSetter() {
+        XCTAssertTrue(machine.isParameterised)
+        XCTAssertEqual(machine.suspendedState, 1)
+        machine.isParameterised = false
+        XCTAssertFalse(machine.isParameterised)
+        XCTAssertEqual(machine.suspendedState, 1)
+        machine.suspendedState = nil
+        XCTAssertNil(machine.suspendedState)
+        XCTAssertFalse(machine.isParameterised)
+        machine.isParameterised = true
+        XCTAssertFalse(machine.isParameterised)
+        XCTAssertNil(machine.suspendedState)
+        machine.suspendedState = 1
+        XCTAssertEqual(machine.suspendedState, 1)
+        XCTAssertFalse(machine.isParameterised)
+        machine.isParameterised = true
+        XCTAssertTrue(machine.isParameterised)
+        XCTAssertEqual(machine.suspendedState, 1)
+    }
+
     // swiftlint:enable force_unwrapping
     // swiftlint:enable function_body_length
 
 }
+
+// swiftlint:enable type_body_length

--- a/Tests/VHDLMachinesTests/codeStructure/CaseStatementTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/CaseStatementTests.swift
@@ -61,9 +61,98 @@ import XCTest
 /// Test class for `CaseStatement` extensions.
 final class CaseStatementTests: XCTestCase {
 
+    /// Some test data.
+    var machine = Machine.testMachine()
+
+    /// Initialise the test data before every test.
+    override func setUp() {
+        self.machine = Machine.testMachine()
+    }
+
     /// Test machine initialiser.
     func testMachineInit() {
-        let machine = Machine.testMachine()
+        let statement = CaseStatement(machine: machine)
+        guard
+            let checkTransition = WhenCase(machine: machine, action: .checkTransition),
+            let `internal` = WhenCase(machine: machine, action: .internal),
+            let noOnEntry = WhenCase(machine: machine, action: .noOnEntry),
+            let onEntry = WhenCase(machine: machine, action: .onEntry),
+            let onExit = WhenCase(machine: machine, action: .onExit),
+            let onResume = WhenCase(machine: machine, action: .onResume),
+            let onSuspend = WhenCase(machine: machine, action: .onSuspend),
+            let readSnapshot = WhenCase(machine: machine, action: .readSnapshot),
+            let writeSnapshot = WhenCase(machine: machine, action: .writeSnapshot)
+        else {
+            XCTFail("Could not create when cases.")
+            return
+        }
+        XCTAssertEqual(
+            statement,
+            CaseStatement(
+                condition: .variable(name: .internalState),
+                cases: [
+                    checkTransition,
+                    `internal`,
+                    noOnEntry,
+                    onEntry,
+                    onExit,
+                    onResume,
+                    onSuspend,
+                    readSnapshot,
+                    writeSnapshot,
+                    .othersNull
+                ]
+            )
+        )
+    }
+
+    /// Test machine initialiser for a machine with invalid actions.
+    func testMachineInitWithInvalidActions() {
+        guard let name = VariableName(rawValue: "InvalidAction") else {
+            XCTFail("Invalid action name.")
+            return
+        }
+        machine.actions.append(name)
+        XCTAssertNil(CaseStatement(machine: machine))
+    }
+
+    /// Test machine initialiser for a non-suspensible machine.
+    func testMachineInitNotSuspensible() {
+        machine.suspendedState = nil
+        let statement = CaseStatement(machine: machine)
+        guard
+            let checkTransition = WhenCase(machine: machine, action: .checkTransition),
+            let `internal` = WhenCase(machine: machine, action: .internal),
+            let noOnEntry = WhenCase(machine: machine, action: .noOnEntry),
+            let onEntry = WhenCase(machine: machine, action: .onEntry),
+            let onExit = WhenCase(machine: machine, action: .onExit),
+            let readSnapshot = WhenCase(machine: machine, action: .readSnapshot),
+            let writeSnapshot = WhenCase(machine: machine, action: .writeSnapshot)
+        else {
+            XCTFail("Could not create when cases.")
+            return
+        }
+        XCTAssertEqual(
+            statement,
+            CaseStatement(
+                condition: .variable(name: .internalState),
+                cases: [
+                    checkTransition,
+                    `internal`,
+                    noOnEntry,
+                    onEntry,
+                    onExit,
+                    readSnapshot,
+                    writeSnapshot,
+                    .othersNull
+                ]
+            )
+        )
+    }
+
+    /// Test machine initialiser when machine isn't parameterised.
+    func testMachineInitNotParameterised() {
+        machine.isParameterised = false
         let statement = CaseStatement(machine: machine)
         guard
             let checkTransition = WhenCase(machine: machine, action: .checkTransition),

--- a/Tests/VHDLMachinesTests/codeStructure/WhenCaseTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/WhenCaseTests.swift
@@ -62,7 +62,7 @@ import XCTest
 final class WhenCaseTests: XCTestCase {
 
     /// A test machine.
-    let machine = Machine.testMachine()
+    var machine = Machine.testMachine()
 
     // swiftlint:disable line_length
 
@@ -277,6 +277,11 @@ final class WhenCaseTests: XCTestCase {
 
     // swiftlint:enable line_length
 
+    /// Create test data before every test.
+    override func setUp() {
+        machine = Machine.testMachine()
+    }
+
     /// Test the checkTransition generation.
     func testCheckTransitionCode() {
         let checkTransition = WhenCase(machine: machine, action: .checkTransition)
@@ -307,10 +312,24 @@ final class WhenCaseTests: XCTestCase {
         XCTAssertEqual(onResume?.rawValue, onResumeCode)
     }
 
+    /// Test onResume for suspensible machine.
+    func testOnResumeSuspensible() {
+        machine.suspendedState = nil
+        let onResume = WhenCase(machine: machine, action: .onResume)
+        XCTAssertNil(onResume)
+    }
+
     /// Test onSuspend generation.
     func testOnSuspendCode() {
         let onSuspend = WhenCase(machine: machine, action: .onSuspend)
         XCTAssertEqual(onSuspend?.rawValue, onSuspendCode)
+    }
+
+    /// Test onSuspend for suspensible machine.
+    func testOnSuspendedSuspensible() {
+        machine.suspendedState = nil
+        let onSuspend = WhenCase(machine: machine, action: .onSuspend)
+        XCTAssertNil(onSuspend)
     }
 
     /// Test internal code generation.

--- a/Tests/VHDLMachinesTests/codeStructure/WhenCaseTests.swift
+++ b/Tests/VHDLMachinesTests/codeStructure/WhenCaseTests.swift
@@ -312,8 +312,8 @@ final class WhenCaseTests: XCTestCase {
         XCTAssertEqual(onResume?.rawValue, onResumeCode)
     }
 
-    /// Test onResume for suspensible machine.
-    func testOnResumeSuspensible() {
+    /// Test onResume for non-suspensible machine.
+    func testOnResumeNotSuspensible() {
         machine.suspendedState = nil
         let onResume = WhenCase(machine: machine, action: .onResume)
         XCTAssertNil(onResume)
@@ -325,8 +325,8 @@ final class WhenCaseTests: XCTestCase {
         XCTAssertEqual(onSuspend?.rawValue, onSuspendCode)
     }
 
-    /// Test onSuspend for suspensible machine.
-    func testOnSuspendedSuspensible() {
+    /// Test onSuspend for non-suspensible machine.
+    func testOnSuspendedNotSuspensible() {
         machine.suspendedState = nil
         let onSuspend = WhenCase(machine: machine, action: .onSuspend)
         XCTAssertNil(onSuspend)


### PR DESCRIPTION
This pull request fixes a bug that was stopping machine generation for VHDL machines that aren't suspensible. This change also introduces an API change by adding a setter to the `isParameterised` property on the `VHDLMachines.Machine` struct.